### PR TITLE
Add `float` to always convert list

### DIFF
--- a/propsToAlwaysConvert.js
+++ b/propsToAlwaysConvert.js
@@ -44,6 +44,7 @@ module.exports = [
     'border-bottom',
     'border-left',
     'box-shadow',
+    'float',
     'margin',
     'padding',
     'text-shadow',


### PR DESCRIPTION
avoids losing `float: none|initial|inherit;`
