### PR TITLE
add support for rtlcss control directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,9 @@ module.exports = postcss.plugin('postcss-inline-rtl', function (opts) {
                 if (rule.nodes[declIndex].type !== 'decl') {
                     continue;
                 }
+                if (rtl.nodes[0].nodes[declIndex] === undefined) {
+                    continue;
+                }
 
                 var decl = rule.nodes[declIndex];
                 var rtlDecl = rtl.nodes[0].nodes[declIndex];

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+/* eslint max-len:0 */
 import postcss from 'postcss';
 import test    from 'ava';
 
@@ -15,4 +16,8 @@ function run(t, input, output, opts = { }) {
 
 test('Checks initial configuration', t => {
     return run(t, 'a{ color: red }', 'a{ color: red }', { });
+});
+
+test('Supports rtlcss control directives', t => {
+    return run(t, 'a{ /*rtl:ignore*/left: 0 }', 'a{ /*rtl:ignore*/left: 0 }', { });
 });


### PR DESCRIPTION
Before this fix, using rtlcss control directives would fail with TypeError:

i.e.
```scss
a {
  /*rtl:ignore*/
  left: auto;
}
```

Exception:

```bash
events.js:160
      throw er; // Unhandled 'error' event
      ^
TypeError: Cannot read property 'raws' of undefined
    at /Code/***/node_modules/postcss-inline-rtl/index.js:97:39
    at /Code/***/node_modules/postcss/lib/container.js:241:28
    at /Code/***/node_modules/postcss/lib/container.js:148:26
    at Root.each (/Code/***/node_modules/postcss/lib/container.js:114:22)
    at Root.walk (/Code/***/node_modules/postcss/lib/container.js:147:21)
    at Root.walkRules (/Code/***/node_modules/postcss/lib/container.js:239:25)
    at /Code/***/node_modules/postcss-inline-rtl/index.js:59:13
    at LazyResult.run (/Code/***/node_modules/postcss/lib/lazy-result.js:274:20)
    at LazyResult.asyncTick (/Code/***/node_modules/postcss/lib/lazy-result.js:189:32)
    at processing.Promise.then._this2.processed (/Code/***/node_modules/postcss/lib/lazy-result.js:228:20)
```